### PR TITLE
Improve the create embeddings app

### DIFF
--- a/rag-embeddings/Cargo.toml
+++ b/rag-embeddings/Cargo.toml
@@ -12,3 +12,4 @@ url = "2.3"
 tokio_wasi = { version = "1", features = ["io-util", "fs", "net", "time", "rt", "macros"] }
 qdrant_rest_client = "0.0.2"
 wasmedge-wasi-nn = "0.7.0"
+clap = {version = "4.5.3", features = ["derive"]}

--- a/rag-embeddings/src/main.rs
+++ b/rag-embeddings/src/main.rs
@@ -8,8 +8,9 @@ use wasmedge_wasi_nn::{
     self, BackendError, Error, ExecutionTarget, GraphBuilder, GraphEncoding, GraphExecutionContext,
     TensorType,
 };
+use clap::{Arg, ArgMatches, Command};
 
-async fn generate_upsert (context: &mut GraphExecutionContext, data: &str, client: &qdrant::Qdrant, id: u64, collection_name: &str, vector_size: usize) {
+async fn generate_upsert (context: &mut GraphExecutionContext, data: &str, client: &qdrant::Qdrant, id: u64, collection_name: &str, vector_size: usize, start_vector_id: u64) {
     set_data_to_context(context, data.as_bytes().to_vec()).unwrap();
     match context.compute() {
         Ok(_) => (),
@@ -30,11 +31,11 @@ async fn generate_upsert (context: &mut GraphExecutionContext, data: &str, clien
         embd_vec.push(embd["embedding"][idx].as_f64().unwrap() as f32);
     }
 
-    println!("{} : ID={} Size={}", OffsetDateTime::now_utc(), id, embd_vec.len());
+    println!("{} : ID={} Size={} Points ID={}", OffsetDateTime::now_utc(), id, embd_vec.len(), start_vector_id + id);
 
     let mut points = Vec::<Point>::new();
     points.push(Point{
-        id: PointId::Num(id), 
+        id: PointId::Num(start_vector_id + id), 
         vector: embd_vec,
         payload: json!({"source": data}).as_object().map(|m| m.to_owned()),
     });
@@ -74,7 +75,28 @@ fn get_embd_from_context(context: &GraphExecutionContext, vector_size: usize) ->
     // println!("\n[EMBED] {}", embd);
     serde_json::from_str(embd).unwrap()
 }
-
+fn parse_parameter(args: &Vec<String>) -> ArgMatches {
+    let matches = Command::new("create_embeddings")
+        .version("1.0")
+        .about("create_embeddings CLI")
+        .disable_help_subcommand(true)
+        .arg(
+            Arg::new("maximum_context_length")
+                .long("maximum_context_length")
+                .short('m')
+                .value_name("maximum_context_length")
+                .help("Maximum context length limitation. If exceeds it, the context will be truncated.")
+        )
+        .arg(
+            Arg::new("start_vector_id")
+                .long("start_vector_id")
+                .short('s')
+                .value_name("start_vector_id")
+                .help("Start vector id. It defaults to 0"),
+        )
+        .get_matches_from(args.clone().split_off(4));
+    return matches;
+}
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let args: Vec<String> = env::args().collect();
@@ -82,6 +104,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let collection_name: &str = &args[2];
     let vector_size: usize = args[3].trim().parse().unwrap();
     let file_name: &str = &args[4];
+    let matches = parse_parameter(&args);
     let mut options = json!({});
     options["embedding"] = serde_json::Value::Bool(true);
     // options["ctx-size"] = serde_json::Value::from(vector_size);
@@ -98,14 +121,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let client = qdrant::Qdrant::new();
 
+    let start_vector_id = match matches.get_one::<String>("start_vector_id") {
+        Some(v) => v.trim().parse().unwrap(),
+        None => 0,
+    };
     let mut id : u64 = 0;
     let mut current_section = String::new();
     let file = File::open(file_name)?;
     let reader = BufReader::new(file);
+    let mut code_mode = false;
     for line_result in reader.lines() {
         let line = line_result?;
-        if line.trim().is_empty() && (!current_section.trim().is_empty()) {
-            generate_upsert(&mut context, &current_section, &client, id, collection_name, vector_size).await;
+        if let Some(_) = line.find("```") {
+            code_mode = !code_mode;
+        }
+        if line.trim().is_empty() && (!current_section.trim().is_empty()) && !code_mode {
+            if let Some(maximum) = matches.get_one::<String>("maximum_context_length") {
+                let maximum = maximum.trim().parse().unwrap();
+                if current_section.len() > maximum {
+                    println!("\n [WARNING] Index: {} exceed maximum contex length limitation.", id);
+                    current_section = current_section[0..maximum].to_string();
+                }
+            }
+            generate_upsert(&mut context, &current_section, &client, id, collection_name, vector_size, start_vector_id).await;
             id += 1;
             // Start a new section
             current_section.clear();
@@ -119,7 +157,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // The last segment
     if !current_section.trim().is_empty() {
-        generate_upsert(&mut context, &current_section, &client, id, collection_name, vector_size).await;
+        if let Some(maximum) = matches.get_one::<String>("maximum_context_length") {
+            let maximum = maximum.trim().parse().unwrap();
+            if current_section.len() > maximum {
+                println!("\n [WARNING] Index: {} exceed maximum contex length limitation.", id);
+                current_section = current_section[0..maximum].to_string();
+            }
+        }
+        generate_upsert(&mut context, &current_section, &client, id, collection_name, vector_size, start_vector_id).await;
     }
     Ok(())
 }

--- a/rag-embeddings/src/main.rs
+++ b/rag-embeddings/src/main.rs
@@ -132,7 +132,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut code_mode = false;
     for line_result in reader.lines() {
         let line = line_result?;
-        if let Some(_) = line.find("```") {
+        if line.trim().starts_with("```") {
             code_mode = !code_mode;
         }
         if line.trim().is_empty() && (!current_section.trim().is_empty()) && !code_mode {


### PR DESCRIPTION
- Using `-m` or `--maximum_context_length` to specify a "context length" in the CLI argument. That is to truncate and warn for each text segment that goes above the context length.
-  Avoid breaking up code listings.
- Using `-s` or `--start_vector_id` to specify the "start vector ID" in the CLI argument. This will allow us to run this app multiple times on multiple documents on the same vector collection.

To avoid breaking argument order, the new argument needs to be added after the original argument.
```
wasmedge --dir .:. \
  --nn-preload embedding:GGML:AUTO:all-MiniLM-L6-v2-ggml-model-f16.gguf \
   create_embeddings.wasm embedding default 384 test2.txt -s 5 -m 50
```